### PR TITLE
Update sodium native version to ^4.0.3, adjust function names to suit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,9 +98,9 @@ class Keychain {
 module.exports = Keychain
 
 function add (a, b, out) {
-  sodium.experimental_crypto_tweak_ed25519_publickey_add(out.publicKey, a.publicKey, b.publicKey)
+  sodium.experimental_crypto_tweak_ed25519_pk_add(out.publicKey, a.publicKey, b.publicKey)
   if (a.scalar && b.scalar) {
-    sodium.experimental_crypto_tweak_ed25519_secretkey_add(out.scalar, a.scalar, b.scalar)
+    sodium.experimental_crypto_tweak_ed25519_scalar_add(out.scalar, a.scalar, b.scalar)
   }
   return out
 }
@@ -130,7 +130,7 @@ function tweakKeyPair (name, prev) {
   const keyPair = allocKeyPair(true)
   const seed = b4a.allocUnsafe(32)
   sodium.crypto_generichash_batch(seed, [prev, name])
-  sodium.experimental_crypto_tweak_ed25519(keyPair.scalar, keyPair.publicKey, seed)
+  sodium.experimental_crypto_tweak_ed25519_base(keyPair.scalar, keyPair.publicKey, seed)
   return keyPair
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keypear",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Keychain that derives deterministic Ed25519 keypairs and attestations",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "b4a": "^1.6.0",
-    "sodium-native": "^3.4.1"
+    "sodium-native": "^4.0.3"
   },
   "devDependencies": {
     "brittle": "^3.1.1",


### PR DESCRIPTION
All tests pass via `npm run test`